### PR TITLE
Add probability logging to simulate

### DIFF
--- a/quantum_secret_hitler/__init__.py
+++ b/quantum_secret_hitler/__init__.py
@@ -1,0 +1,6 @@
+"Quantum Secret Hitler package"
+
+from . import constants
+from .simulate import QuantumSecretHitlerGame
+
+__all__ = ["constants", "QuantumSecretHitlerGame"]

--- a/quantum_secret_hitler/__init__.py
+++ b/quantum_secret_hitler/__init__.py
@@ -1,6 +1,6 @@
 "Quantum Secret Hitler package"
 
-from . import constants
-from .simulate import QuantumSecretHitlerGame
+import constants
+from simulate import QuantumSecretHitlerGame
 
 __all__ = ["constants", "QuantumSecretHitlerGame"]

--- a/quantum_secret_hitler/constants.py
+++ b/quantum_secret_hitler/constants.py
@@ -1,0 +1,66 @@
+"""Module storing constants for the Quantum Secret Hitler game.
+
+This module centralizes numeric values so the rest of the code can simply
+import ``constants``.  In addition to the deck composition, we fix the total
+number of players to 10 and the distribution of liberals and fascists.
+The angles used in the voting and policy selection procedures are derived
+from the ``DELTA`` parameter described in ``IQU_CODE_FEST_CapitalQ.pdf``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Number of liberal and fascist policies in the deck
+LIBERAL_POLICIES = 6
+FASCIST_POLICIES = 11
+TOTAL_POLICIES = LIBERAL_POLICIES + FASCIST_POLICIES
+
+# ---------------------------------------------------------------------------
+# Player distribution
+# ---------------------------------------------------------------------------
+
+# Total number of people in the game.  The PDF explicitly considers a ten
+# player session, so we keep that fixed for the simple simulator.
+PLAYER_COUNT = 10
+
+# For a ten-player game the classical distribution is six liberals and four
+# fascists.  The ``FASCIST_PLAYERS`` value counts everyone who initially plays
+# for the fascist team.  The Hitler role is chosen among them.
+LIBERAL_PLAYERS = 6
+FASCIST_PLAYERS = PLAYER_COUNT - LIBERAL_PLAYERS
+
+# ---------------------------------------------------------------------------
+# Voting and policy selection parameters
+# ---------------------------------------------------------------------------
+
+# Constant ``c`` controlling the bias of an individual vote.  The instructions
+# give ``0 < c < 2`` so that ``delta = c/(N-1)`` remains below ``1/2``.
+VOTE_BIAS_C = 1.0
+# Derived "delta" value and rotation angle ``phi`` used in the voting circuit.
+VOTE_DELTA = VOTE_BIAS_C / (PLAYER_COUNT - 1)
+VOTE_PHI = np.arcsin(2 * VOTE_DELTA)
+
+# ``POLICY_PHI`` controls the bias when the president and chancellor draw a
+# policy.  For simplicity we use the same angle as the voting procedure.
+POLICY_PHI = VOTE_PHI
+
+# Probability of drawing a liberal policy when both president and
+# chancellor favour liberal action
+LIBERAL_POLICY_PROBABILITY = 0.8
+
+# Bullet mechanic probabilities
+BULLET_TARGET_PROB = 0.8
+BULLET_OTHER_PROB = 0.2
+
+# Bounds for the unsharp measurement parameter
+MIN_ETA = 0.0
+MAX_ETA = 1.0
+
+# ---------------------------------------------------------------------------
+# Victory conditions
+# ---------------------------------------------------------------------------
+
+# Number of liberal and fascist policies required for each side to win.
+LIBERAL_WIN_POLICIES = 5
+FASCIST_WIN_POLICIES = 6

--- a/quantum_secret_hitler/constants.py
+++ b/quantum_secret_hitler/constants.py
@@ -64,3 +64,12 @@ MAX_ETA = 1.0
 # Number of liberal and fascist policies required for each side to win.
 LIBERAL_WIN_POLICIES = 5
 FASCIST_WIN_POLICIES = 6
+
+# ---------------------------------------------------------------------------
+# Hitler distribution update
+# ---------------------------------------------------------------------------
+
+# Factor used to bias the Hitler probability toward a player when they take a
+# fascist-leaning action.  A value greater than ``1`` increases the chance that
+# the player is Hitler while keeping a non-zero probability for others.
+HITLER_BIAS_FACTOR = 1.2

--- a/quantum_secret_hitler/constants.py
+++ b/quantum_secret_hitler/constants.py
@@ -42,12 +42,15 @@ VOTE_DELTA = VOTE_BIAS_C / (PLAYER_COUNT - 1)
 VOTE_PHI = np.arcsin(2 * VOTE_DELTA)
 
 # ``POLICY_PHI`` controls the bias when the president and chancellor draw a
-# policy.  For simplicity we use the same angle as the voting procedure.
-POLICY_PHI = VOTE_PHI
+# policy.  It is chosen so that if both players favour a liberal action the
+# probability of drawing a liberal policy is ``LIBERAL_POLICY_PROBABILITY``.
 
 # Probability of drawing a liberal policy when both president and
 # chancellor favour liberal action
 LIBERAL_POLICY_PROBABILITY = 0.8
+
+_alpha = np.arctan(np.sqrt(FASCIST_POLICIES / LIBERAL_POLICIES))
+POLICY_PHI = np.pi - _alpha - np.arccos(np.sqrt(LIBERAL_POLICY_PROBABILITY))
 
 # Bullet mechanic probabilities
 BULLET_TARGET_PROB = 0.8

--- a/quantum_secret_hitler/game.py
+++ b/quantum_secret_hitler/game.py
@@ -16,7 +16,7 @@ from qiskit import QuantumCircuit
 from qiskit_aer import Aer
 from qiskit.quantum_info import Statevector, Kraus
 
-from . import constants
+import constants
 
 
 def uniform_role_state(num_players: int, num_liberals: int) -> Statevector:

--- a/quantum_secret_hitler/game.py
+++ b/quantum_secret_hitler/game.py
@@ -1,0 +1,113 @@
+"""Quantum Secret Hitler utilities.
+
+This module implements key quantum mechanics for the Secret Hitler variant
+outlined in ``IQU_CODE_FEST_CapitalQ.pdf``. It focuses on preparing the
+initial role distribution, running the quantum voting procedure, selecting
+policies with quantum bias, the randomized bullet mechanic, and unsharp role
+measurements.
+"""
+from __future__ import annotations
+
+import itertools
+from typing import List, Tuple
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit_aer import Aer
+from qiskit.quantum_info import Statevector, Kraus
+
+from . import constants
+
+
+def uniform_role_state(num_players: int, num_liberals: int) -> Statevector:
+    """Return the superposition assigning roles as in Eq. (1)."""
+    if not 0 < num_liberals < num_players:
+        raise ValueError("num_liberals must be between 1 and num_players - 1")
+
+    dim = 2 ** num_players
+    amps = np.zeros(dim, dtype=complex)
+    for bits in itertools.product([0, 1], repeat=num_players):
+        if bits.count(0) == num_liberals:
+            idx = int("".join(str(b) for b in bits), 2)
+            amps[idx] = 1
+    amps /= np.linalg.norm(amps)
+    return Statevector(amps)
+
+
+def uniform_hitler_state(num_fascists: int) -> Statevector:
+    """Return the initial Hitler distribution among the fascists (Eq. 2)."""
+    if num_fascists <= 0:
+        raise ValueError("There must be at least one fascist")
+
+    dim = 2 ** num_fascists
+    amps = np.zeros(dim, dtype=complex)
+    for j in range(num_fascists):
+        amps[1 << j] = 1
+    amps /= np.sqrt(num_fascists)
+    return Statevector(amps)
+
+
+def quantum_vote(votes: List[int], phi: float) -> Tuple[int, Statevector]:
+    """Run the quantum voting procedure for a proposed chancellor."""
+    qc = QuantumCircuit(1)
+    qc.h(0)
+    for v in votes:
+        qc.ry(phi if v else -phi, 0)
+
+    qc.save_statevector()
+    backend = Aer.get_backend("aer_simulator")
+    result = backend.run(qc).result()
+    state = Statevector(result.get_statevector())
+    outcome = np.random.choice([0, 1], p=state.probabilities())
+    return int(outcome), state
+
+
+def policy_selection(pres_bias: int, chan_bias: int, phi: float) -> Tuple[int, Statevector]:
+    """Simulate policy drawing as described in the PDF."""
+    qc = QuantumCircuit(1)
+    qc.initialize(
+        [
+            np.sqrt(constants.LIBERAL_POLICIES / constants.TOTAL_POLICIES),
+            np.sqrt(constants.FASCIST_POLICIES / constants.TOTAL_POLICIES),
+        ],
+        0,
+    )
+
+    qc.ry(phi if pres_bias == 1 else -phi / 2, 0)
+    qc.ry(phi if chan_bias == 1 else -phi / 2, 0)
+
+    qc.save_statevector()
+    backend = Aer.get_backend("aer_simulator")
+    result = backend.run(qc).result()
+    state = Statevector(result.get_statevector())
+    outcome = np.random.choice([0, 1], p=state.probabilities())
+    return int(outcome), state
+
+
+def biased_bullet_state(num_players: int, target: int) -> Statevector:
+    """Return ``|Ψ_i⟩`` (Eq. 11) favouring ``target`` to be shot."""
+    if not 0 <= target < num_players:
+        raise ValueError("target index out of range")
+    amps = np.full(
+        num_players,
+        np.sqrt(constants.BULLET_OTHER_PROB / (num_players - 1)),
+        dtype=complex,
+    )
+    amps[target] = np.sqrt(constants.BULLET_TARGET_PROB)
+    return Statevector(amps)
+
+
+def unsharp_measure(state: Statevector, eta: float) -> Statevector:
+    """Apply an unsharp measurement with parameter ``eta`` to ``state``."""
+    if not constants.MIN_ETA <= eta <= constants.MAX_ETA:
+        raise ValueError(
+            f"eta must be between {constants.MIN_ETA} and {constants.MAX_ETA}"
+        )
+    mh = np.array([[np.sqrt((1 - eta) / 2), 0], [0, np.sqrt((1 + eta) / 2)]])
+    mnh = np.array([[np.sqrt((1 + eta) / 2), 0], [0, np.sqrt((1 - eta) / 2)]])
+    kraus = [mh, mnh]
+    channel = Kraus(kraus)
+    probs = channel.probabilities(state)
+    outcome = np.random.choice([0, 1], p=probs)
+    new_state = channel._channel_matrices[outcome] @ state.data
+    return Statevector(new_state)

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -213,8 +213,24 @@ class QuantumSecretHitlerGame:
                 print("No chancellor elected")
                 return
         else:
-            pres_bias = 1 if self.players[self.president].role == "liberal" else 0
-            chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
+            if interactive:
+                ans = input(
+                    f"Should president {self.president} favour liberal policy? (y/n, enter for role-based) "
+                ).strip().lower()
+                if ans in {"y", "n"}:
+                    pres_bias = 1 if ans == "y" else 0
+                else:
+                    pres_bias = 1 if self.players[self.president].role == "liberal" else 0
+                ans = input(
+                    f"Should chancellor {chancellor} favour liberal policy? (y/n, enter for role-based) "
+                ).strip().lower()
+                if ans in {"y", "n"}:
+                    chan_bias = 1 if ans == "y" else 0
+                else:
+                    chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
+            else:
+                pres_bias = 1 if self.players[self.president].role == "liberal" else 0
+                chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
             policy, state = policy_selection(pres_bias, chan_bias, constants.POLICY_PHI)
             if pres_bias == 0:
                 self._bias_hitler_distribution(self.president)
@@ -226,11 +242,6 @@ class QuantumSecretHitlerGame:
             )
             if interactive:
                 self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
-                raw = input(
-                    "Choose policy 0=Liberal, 1=Fascist (enter for random result): "
-                ).strip()
-                if raw in {"0", "1"}:
-                    policy = int(raw)
             print(
                 f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy"
             )

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -77,7 +77,8 @@ class QuantumSecretHitlerGame:
             constants.PLAYER_COUNT, constants.LIBERAL_PLAYERS
         )
         probs = state.probabilities()
-        uniform_prob = 1 / len(probs)
+        from math import comb
+        uniform_prob = 1 / comb(constants.PLAYER_COUNT, constants.LIBERAL_PLAYERS)
         print(f"Role assignment probability for each valid state: {uniform_prob:.4f}")
         outcome = np.random.choice(2 ** self.num_players, p=probs)
         bits = list(map(int, bin(outcome)[2:].zfill(self.num_players)))

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -14,8 +14,8 @@ from argparse import ArgumentParser
 
 import matplotlib.pyplot as plt
 
-from . import constants
-from .game import (
+import constants
+from game import (
     uniform_role_state,
     uniform_hitler_state,
     quantum_vote,
@@ -186,7 +186,8 @@ class QuantumSecretHitlerGame:
             f"Vote probabilities -> Fail: {probs[0]:.2f}, Success: {probs[1]:.2f}"
         )
         if interactive:
-            self._plot_distribution(["Fail", "Success"], list(probs), "Vote outcome")
+            # self._plot_distribution(["Fail", "Success"], list(probs), "Vote outcome")
+            ...
         if success:
             print("Election successful")
         else:
@@ -206,7 +207,8 @@ class QuantumSecretHitlerGame:
                     f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
                 )
                 if interactive:
-                    self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+                    # self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+                    ...
                 self.failed_elections = 0
                 print("Top-deck policy due to anarchy")
             else:
@@ -241,7 +243,8 @@ class QuantumSecretHitlerGame:
                 f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
             )
             if interactive:
-                self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+                # self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+                ...
             print(
                 f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy"
             )
@@ -275,7 +278,8 @@ class QuantumSecretHitlerGame:
         dist = {alive[i].index: round(prob, 2) for i, prob in enumerate(probs)}
         print(f"Bullet probabilities: {dist}")
         if interactive:
-            self._plot_distribution([str(p.index) for p in alive], list(probs), "Bullet outcome")
+            # self._plot_distribution([str(p.index) for p in alive], list(probs), "Bullet outcome")
+            ...
         shot_idx_local = int(np.random.choice(len(alive), p=probs))
         shot = alive[shot_idx_local].index
         self.players[shot].alive = False
@@ -321,14 +325,15 @@ class QuantumSecretHitlerGame:
         while True:
             result = self.play_round(interactive)
             if interactive:
-                self._visualize()
+                # self._visualize()
                 ans = input("Press Enter for next round or 'q' to quit: ")
                 if ans.lower().startswith("q"):
                     print("Game aborted.")
                     break
             if result:
                 if interactive:
-                    self._visualize()
+                    # self._visualize()
+                    ...
                 print(f"\n{result} win the game!")
                 return result
         return "Aborted"

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -225,7 +225,14 @@ class QuantumSecretHitlerGame:
             )
             if interactive:
                 self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
-            print(f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy")
+                raw = input(
+                    "Choose policy 0=Liberal, 1=Fascist (enter for random result): "
+                ).strip()
+                if raw in {"0", "1"}:
+                    policy = int(raw)
+            print(
+                f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy"
+            )
 
         if policy == 0:
             self.liberal_policies += 1

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -1,0 +1,223 @@
+"""Simple simulation of the Quantum Secret Hitler game.
+
+This module provides a ``QuantumSecretHitlerGame`` class capable of running a
+single simulated game with the rules sketched in ``IQU_CODE_FEST_CapitalQ.pdf``.
+The implementation focuses on the quantum-inspired mechanics while keeping the
+control flow lightweight so it can run entirely offline.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import List, Optional
+import sys
+
+from . import constants
+from .game import (
+    uniform_role_state,
+    uniform_hitler_state,
+    quantum_vote,
+    policy_selection,
+    biased_bullet_state,
+)
+
+
+class Player:
+    """Represents a player in the game."""
+
+    def __init__(self, index: int, role: str) -> None:
+        self.index = index
+        self.role = role  # "liberal" or "fascist"
+        self.alive = True
+
+
+class QuantumSecretHitlerGame:
+    """Manage a single run of the game with 10 players."""
+
+    def __init__(self) -> None:
+        self.num_players = constants.PLAYER_COUNT
+        self.players = self._assign_roles()
+        self.hitler = self._assign_hitler()
+        self.president = np.random.randint(self.num_players)
+
+        print("Initial roles:")
+        for p in self.players:
+            print(f"  Player {p.index}: {p.role}")
+        lib_prob = constants.LIBERAL_PLAYERS / constants.PLAYER_COUNT
+        print(
+            f"Role probabilities -> Liberal: {lib_prob:.2f}, Fascist: {1-lib_prob:.2f}"
+        )
+        fascists = [p.index for p in self.players if p.role == "fascist"]
+        if fascists:
+            hit_prob = 1 / len(fascists)
+            print(
+                f"Hitler probability for each fascist: {hit_prob:.2f}"
+            )
+        print(f"Hitler is player {self.hitler}\n")
+
+        self.liberal_policies = 0
+        self.fascist_policies = 0
+        self.failed_elections = 0
+        self.round = 0
+
+    # ------------------------------------------------------------------
+    # Role assignment helpers
+    # ------------------------------------------------------------------
+    def _assign_roles(self) -> List[Player]:
+        """Measure ``|Ψ_role⟩`` once to distribute liberal/fascist roles."""
+        state = uniform_role_state(
+            constants.PLAYER_COUNT, constants.LIBERAL_PLAYERS
+        )
+        probs = state.probabilities()
+        uniform_prob = 1 / len(probs)
+        print(f"Role assignment probability for each valid state: {uniform_prob:.4f}")
+        outcome = np.random.choice(2 ** self.num_players, p=probs)
+        bits = list(map(int, bin(outcome)[2:].zfill(self.num_players)))
+        players: List[Player] = []
+        for i, b in enumerate(bits):
+            role = "liberal" if b == 0 else "fascist"
+            players.append(Player(i, role))
+        return players
+
+    def _assign_hitler(self) -> int:
+        """Randomly pick the initial Hitler among the fascists."""
+        fascists = [p.index for p in self.players if p.role == "fascist"]
+        state = uniform_hitler_state(len(fascists))
+        hit_prob = 1 / len(fascists)
+        dist = {f: round(hit_prob, 2) for f in fascists}
+        print(f"Initial Hitler distribution: {dist}")
+        outcome = np.random.choice(fascists, p=[hit_prob] * len(fascists))
+        return outcome
+
+    # ------------------------------------------------------------------
+    # Basic helpers
+    # ------------------------------------------------------------------
+    def _alive_players(self) -> List[Player]:
+        return [p for p in self.players if p.alive]
+
+    def _next_president(self) -> None:
+        idx = self.president
+        while True:
+            idx = (idx + 1) % self.num_players
+            if self.players[idx].alive:
+                self.president = idx
+                break
+
+    # ------------------------------------------------------------------
+    # Game mechanics
+    # ------------------------------------------------------------------
+    def _elect_chancellor(self) -> Optional[int]:
+        alive = self._alive_players()
+        choices = [p.index for p in alive if p.index != self.president]
+        candidate = int(np.random.choice(choices))
+
+        print(f"President {self.president} nominates player {candidate} as chancellor")
+
+        votes = [1 if p.role == self.players[candidate].role else 0 for p in alive]
+        print(f"Votes: {votes}")
+        success, state = quantum_vote(votes, constants.VOTE_PHI)
+        probs = state.probabilities()
+        print(
+            f"Vote probabilities -> Fail: {probs[0]:.2f}, Success: {probs[1]:.2f}"
+        )
+        if success:
+            print("Election successful")
+        else:
+            print("Election failed")
+        if success:
+            self.failed_elections = 0
+            return candidate
+        self.failed_elections += 1
+        return None
+
+    def _enact_policy(self, chancellor: Optional[int]) -> None:
+        if chancellor is None:
+            if self.failed_elections >= 3:
+                policy, state = policy_selection(0, 0, constants.POLICY_PHI)
+                probs = state.probabilities()
+                print(
+                    f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
+                )
+                self.failed_elections = 0
+                print("Top-deck policy due to anarchy")
+            else:
+                print("No chancellor elected")
+                return
+        else:
+            pres_bias = 1 if self.players[self.president].role == "liberal" else 0
+            chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
+            policy, state = policy_selection(pres_bias, chan_bias, constants.POLICY_PHI)
+            probs = state.probabilities()
+            print(
+                f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
+            )
+            print(f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy")
+
+        if policy == 0:
+            self.liberal_policies += 1
+        else:
+            self.fascist_policies += 1
+        print(
+            f"Policies -> Liberal: {self.liberal_policies}, Fascist: {self.fascist_policies}"
+        )
+
+    def _bullet_phase(self) -> None:
+        if self.fascist_policies not in (4, 5):
+            return
+        alive = self._alive_players()
+        choices = [p.index for p in alive if p.index != self.president]
+        target = int(np.random.choice(choices))
+        print(f"President {self.president} chooses policy kill targeting player {target}")
+        target_local = [p.index for p in alive].index(target)
+        bullet_state = biased_bullet_state(len(alive), target_local)
+        probs = bullet_state.probabilities()
+        dist = {alive[i].index: round(prob, 2) for i, prob in enumerate(probs)}
+        print(f"Bullet probabilities: {dist}")
+        shot_idx_local = int(np.random.choice(len(alive), p=probs))
+        shot = alive[shot_idx_local].index
+        self.players[shot].alive = False
+        print(f"Player {shot} was shot")
+        if shot == self.hitler:
+            print("Hitler was eliminated!")
+        if shot == self.hitler:
+            # Immediate liberal victory
+            self.liberal_policies = constants.LIBERAL_WIN_POLICIES
+
+    def _check_winner(self, chancellor: Optional[int]) -> Optional[str]:
+        if (
+            chancellor is not None
+            and chancellor == self.hitler
+            and self.fascist_policies >= 3
+        ):
+            print("Hitler elected as chancellor - Fascists win!")
+            return "Fascists"
+        if self.fascist_policies >= constants.FASCIST_WIN_POLICIES:
+            print("Fascists have enough policies to win")
+            return "Fascists"
+        if self.liberal_policies >= constants.LIBERAL_WIN_POLICIES:
+            print("Liberals enacted enough policies to win")
+            return "Liberals"
+        return None
+
+    def play_round(self) -> Optional[str]:
+        self.round += 1
+        print(f"\n--- Round {self.round} ---")
+        print(f"President is {self.president}")
+        chancellor = self._elect_chancellor()
+        self._enact_policy(chancellor)
+        self._bullet_phase()
+        winner = self._check_winner(chancellor)
+        self._next_president()
+        return winner
+
+    def play_game(self) -> str:
+        while True:
+            result = self.play_round()
+            if result:
+                print(f"\n{result} win the game!")
+                return result
+
+
+if __name__ == "__main__":
+    game = QuantumSecretHitlerGame()
+    game.play_game()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pylatexenc==2.10
 plotly==6.0.1
 imageio==2.37.0
 tqdm==4.67.1
+


### PR DESCRIPTION
## Summary
- log uniform role distribution probability and Hitler assignment probabilities
- print probabilities for voting, policy selection, and bullet outcomes

## Testing
- `python -m compileall quantum_secret_hitler`
- `pip install -r requirements.txt`
- `python -m quantum_secret_hitler.simulate`

------
https://chatgpt.com/codex/tasks/task_e_68557c8900988322a716137afbd7b95d