### PR TITLE
Interactive policy override

### DIFF
--- a/quantum_secret_hitler/__init__.py
+++ b/quantum_secret_hitler/__init__.py
@@ -1,0 +1,7 @@
+"Quantum Secret Hitler package"
+
+from . import constants
+from .simulate import QuantumSecretHitlerGame
+from .gui import SecretHitlerGUI
+
+__all__ = ["constants", "QuantumSecretHitlerGame", "SecretHitlerGUI"]

--- a/quantum_secret_hitler/constants.py
+++ b/quantum_secret_hitler/constants.py
@@ -1,0 +1,81 @@
+"""Module storing constants for the Quantum Secret Hitler game.
+
+This module centralizes numeric values so the rest of the code can simply
+import ``constants``.  In addition to the deck composition, we fix the total
+number of players to 10 and the distribution of liberals and fascists.
+The angles used in the voting and policy selection procedures are derived
+from the ``DELTA`` parameter described in ``IQU_CODE_FEST_CapitalQ.pdf``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Number of liberal and fascist policies in the deck
+LIBERAL_POLICIES = 6
+FASCIST_POLICIES = 11
+TOTAL_POLICIES = LIBERAL_POLICIES + FASCIST_POLICIES
+
+# ---------------------------------------------------------------------------
+# Player distribution
+# ---------------------------------------------------------------------------
+
+# Total number of people in the game.  The PDF explicitly considers a ten
+# player session, so we keep that fixed for the simple simulator.
+PLAYER_COUNT = 10
+
+# For a ten-player game the classical distribution is six liberals and four
+# fascists.  The ``FASCIST_PLAYERS`` value counts everyone who initially plays
+# for the fascist team.  The Hitler role is chosen among them.
+LIBERAL_PLAYERS = 6
+FASCIST_PLAYERS = PLAYER_COUNT - LIBERAL_PLAYERS
+
+# ---------------------------------------------------------------------------
+# Voting and policy selection parameters
+# ---------------------------------------------------------------------------
+
+# Constant ``c`` controlling the bias of an individual vote.  The instructions
+# give ``0 < c < 2`` so that ``delta = c/(N-1)`` remains below ``1/2``.
+VOTE_BIAS_C = 1.0
+# Derived "delta" value and rotation angle ``phi`` used in the voting circuit.
+VOTE_DELTA = VOTE_BIAS_C / (PLAYER_COUNT - 1)
+VOTE_PHI = np.arcsin(2 * VOTE_DELTA)
+
+# ``POLICY_PHI`` controls the bias when the president and chancellor draw a
+# policy.  It is chosen so that if both players favour a liberal action the
+# probability of drawing a liberal policy is ``LIBERAL_POLICY_PROBABILITY``.
+
+# Probability of drawing a liberal policy when both president and
+# chancellor favour liberal action
+LIBERAL_POLICY_PROBABILITY = 0.8
+
+# Base angle describing the neutral deck state. ``POLICY_PHI`` is chosen so
+# that applying it twice raises the liberal probability to
+# ``LIBERAL_POLICY_PROBABILITY`` when both leaders favour a liberal policy.
+_theta = np.arccos(np.sqrt(LIBERAL_POLICIES / TOTAL_POLICIES))
+POLICY_PHI = np.arccos(np.sqrt(LIBERAL_POLICY_PROBABILITY)) - _theta
+
+# Bullet mechanic probabilities
+BULLET_TARGET_PROB = 0.8
+BULLET_OTHER_PROB = 0.2
+
+# Bounds for the unsharp measurement parameter
+MIN_ETA = 0.0
+MAX_ETA = 1.0
+
+# ---------------------------------------------------------------------------
+# Victory conditions
+# ---------------------------------------------------------------------------
+
+# Number of liberal and fascist policies required for each side to win.
+LIBERAL_WIN_POLICIES = 5
+FASCIST_WIN_POLICIES = 6
+
+# ---------------------------------------------------------------------------
+# Hitler distribution update
+# ---------------------------------------------------------------------------
+
+# Factor used to bias the Hitler probability toward a player when they take a
+# fascist-leaning action.  A value greater than ``1`` increases the chance that
+# the player is Hitler while keeping a non-zero probability for others.
+HITLER_BIAS_FACTOR = 1.2

--- a/quantum_secret_hitler/game.py
+++ b/quantum_secret_hitler/game.py
@@ -1,0 +1,113 @@
+"""Quantum Secret Hitler utilities.
+
+This module implements key quantum mechanics for the Secret Hitler variant
+outlined in ``IQU_CODE_FEST_CapitalQ.pdf``. It focuses on preparing the
+initial role distribution, running the quantum voting procedure, selecting
+policies with quantum bias, the randomized bullet mechanic, and unsharp role
+measurements.
+"""
+from __future__ import annotations
+
+import itertools
+from typing import List, Tuple
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit_aer import Aer
+from qiskit.quantum_info import Statevector, Kraus
+
+from . import constants
+
+
+def uniform_role_state(num_players: int, num_liberals: int) -> Statevector:
+    """Return the superposition assigning roles as in Eq. (1)."""
+    if not 0 < num_liberals < num_players:
+        raise ValueError("num_liberals must be between 1 and num_players - 1")
+
+    dim = 2 ** num_players
+    amps = np.zeros(dim, dtype=complex)
+    for bits in itertools.product([0, 1], repeat=num_players):
+        if bits.count(0) == num_liberals:
+            idx = int("".join(str(b) for b in bits), 2)
+            amps[idx] = 1
+    amps /= np.linalg.norm(amps)
+    return Statevector(amps)
+
+
+def uniform_hitler_state(num_fascists: int) -> Statevector:
+    """Return the initial Hitler distribution among the fascists (Eq. 2)."""
+    if num_fascists <= 0:
+        raise ValueError("There must be at least one fascist")
+
+    dim = 2 ** num_fascists
+    amps = np.zeros(dim, dtype=complex)
+    for j in range(num_fascists):
+        amps[1 << j] = 1
+    amps /= np.sqrt(num_fascists)
+    return Statevector(amps)
+
+
+def quantum_vote(votes: List[int], phi: float) -> Tuple[int, Statevector]:
+    """Run the quantum voting procedure for a proposed chancellor."""
+    qc = QuantumCircuit(1)
+    qc.h(0)
+    for v in votes:
+        qc.ry(phi if v else -phi, 0)
+
+    qc.save_statevector()
+    backend = Aer.get_backend("aer_simulator")
+    result = backend.run(qc).result()
+    state = Statevector(result.get_statevector())
+    outcome = np.random.choice([0, 1], p=state.probabilities())
+    return int(outcome), state
+
+
+def policy_selection(pres_bias: int, chan_bias: int, phi: float) -> Tuple[int, Statevector]:
+    """Simulate policy drawing as described in the PDF."""
+    qc = QuantumCircuit(1)
+    qc.initialize(
+        [
+            np.sqrt(constants.LIBERAL_POLICIES / constants.TOTAL_POLICIES),
+            np.sqrt(constants.FASCIST_POLICIES / constants.TOTAL_POLICIES),
+        ],
+        0,
+    )
+
+    qc.ry(phi if pres_bias == 1 else -phi / 2, 0)
+    qc.ry(phi if chan_bias == 1 else -phi / 2, 0)
+
+    qc.save_statevector()
+    backend = Aer.get_backend("aer_simulator")
+    result = backend.run(qc).result()
+    state = Statevector(result.get_statevector())
+    outcome = np.random.choice([0, 1], p=state.probabilities())
+    return int(outcome), state
+
+
+def biased_bullet_state(num_players: int, target: int) -> Statevector:
+    """Return ``|Ψ_i⟩`` (Eq. 11) favouring ``target`` to be shot."""
+    if not 0 <= target < num_players:
+        raise ValueError("target index out of range")
+    amps = np.full(
+        num_players,
+        np.sqrt(constants.BULLET_OTHER_PROB / (num_players - 1)),
+        dtype=complex,
+    )
+    amps[target] = np.sqrt(constants.BULLET_TARGET_PROB)
+    return Statevector(amps)
+
+
+def unsharp_measure(state: Statevector, eta: float) -> Statevector:
+    """Apply an unsharp measurement with parameter ``eta`` to ``state``."""
+    if not constants.MIN_ETA <= eta <= constants.MAX_ETA:
+        raise ValueError(
+            f"eta must be between {constants.MIN_ETA} and {constants.MAX_ETA}"
+        )
+    mh = np.array([[np.sqrt((1 - eta) / 2), 0], [0, np.sqrt((1 + eta) / 2)]])
+    mnh = np.array([[np.sqrt((1 + eta) / 2), 0], [0, np.sqrt((1 - eta) / 2)]])
+    kraus = [mh, mnh]
+    channel = Kraus(kraus)
+    probs = channel.probabilities(state)
+    outcome = np.random.choice([0, 1], p=probs)
+    new_state = channel._channel_matrices[outcome] @ state.data
+    return Statevector(new_state)

--- a/quantum_secret_hitler/gui.py
+++ b/quantum_secret_hitler/gui.py
@@ -1,0 +1,77 @@
+"""Simple Tkinter interface for the Quantum Secret Hitler game."""
+from __future__ import annotations
+
+import io
+import tkinter as tk
+from contextlib import redirect_stdout
+
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+
+from .simulate import QuantumSecretHitlerGame
+from . import constants
+
+
+class SecretHitlerGUI(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Quantum Secret Hitler")
+        self.game = None
+
+        self.text = tk.Text(self, width=80, height=20)
+        self.text.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        button_frame = tk.Frame(self)
+        button_frame.pack(side=tk.TOP, fill=tk.X)
+        self.next_btn = tk.Button(button_frame, text="Next Round", command=self.next_round)
+        self.next_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        self.quit_btn = tk.Button(button_frame, text="Quit", command=self.destroy)
+        self.quit_btn.pack(side=tk.LEFT, padx=5, pady=5)
+
+        # matplotlib figure for policy counts
+        self.fig, self.ax = plt.subplots(figsize=(4, 3))
+        self.ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        self._start_game()
+
+    def _start_game(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.game = QuantumSecretHitlerGame()
+        self._append(buf.getvalue())
+        self._update_plot()
+
+    def _append(self, text: str) -> None:
+        self.text.insert(tk.END, text)
+        self.text.see(tk.END)
+
+    def _update_plot(self) -> None:
+        self.ax.clear()
+        self.ax.bar([
+            "Liberal",
+            "Fascist",
+        ], [self.game.liberal_policies, self.game.fascist_policies], color=["blue", "red"])
+        self.ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
+        self.ax.set_title(f"Round {self.game.round}")
+        self.canvas.draw()
+
+    def next_round(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            winner = self.game.play_round(interactive=False)
+        self._append(buf.getvalue())
+        self._update_plot()
+        if winner:
+            self._append(f"\n{winner} win the game!\n")
+            self.next_btn.config(state=tk.DISABLED)
+
+
+def main() -> None:
+    app = SecretHitlerGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/quantum_secret_hitler/gui.py
+++ b/quantum_secret_hitler/gui.py
@@ -1,9 +1,17 @@
-"""Simple Tkinter interface for the Quantum Secret Hitler game."""
+"""Tkinter interface for the Quantum Secret Hitler game.
+
+This GUI displays the players around a round table. The president is
+highlighted and players are clickable so the user can choose the
+chancellor nominee and bullet target. Side panels show the current
+probability distributions and game state.
+"""
 from __future__ import annotations
 
 import io
+import math
 import tkinter as tk
 from contextlib import redirect_stdout
+from typing import Dict, Optional
 
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import matplotlib.pyplot as plt
@@ -12,60 +20,237 @@ from .simulate import QuantumSecretHitlerGame
 from . import constants
 
 
+PLAYER_RADIUS = 20
+TABLE_RADIUS = 180
+CANVAS_SIZE = 400
+
+
 class SecretHitlerGUI(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title("Quantum Secret Hitler")
-        self.game = None
+        self.game = QuantumSecretHitlerGame()
 
-        self.text = tk.Text(self, width=80, height=20)
-        self.text.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        # --- widgets -----------------------------------------------------
+        self.canvas = tk.Canvas(self, width=CANVAS_SIZE, height=CANVAS_SIZE, bg="darkgreen")
+        self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.canvas.bind("<Button-1>", self._on_canvas_click)
 
-        button_frame = tk.Frame(self)
-        button_frame.pack(side=tk.TOP, fill=tk.X)
-        self.next_btn = tk.Button(button_frame, text="Next Round", command=self.next_round)
-        self.next_btn.pack(side=tk.LEFT, padx=5, pady=5)
-        self.quit_btn = tk.Button(button_frame, text="Quit", command=self.destroy)
-        self.quit_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        sidebar = tk.Frame(self)
+        sidebar.pack(side=tk.RIGHT, fill=tk.Y)
 
-        # matplotlib figure for policy counts
-        self.fig, self.ax = plt.subplots(figsize=(4, 3))
-        self.ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
-        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
-        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self.log = tk.Text(sidebar, width=40, height=15)
+        self.log.pack(fill=tk.BOTH, expand=True)
 
-        self._start_game()
+        self.instr = tk.Label(sidebar, text="Click 'Next Round' to begin")
+        self.instr.pack(pady=4)
 
-    def _start_game(self) -> None:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            self.game = QuantumSecretHitlerGame()
-        self._append(buf.getvalue())
-        self._update_plot()
+        ctrl = tk.Frame(sidebar)
+        ctrl.pack(pady=4)
+        self.next_btn = tk.Button(ctrl, text="Next Round", command=self.start_round)
+        self.next_btn.pack(side=tk.LEFT)
+        tk.Button(ctrl, text="Quit", command=self.destroy).pack(side=tk.LEFT, padx=5)
 
-    def _append(self, text: str) -> None:
-        self.text.insert(tk.END, text)
-        self.text.see(tk.END)
+        self.vote_frame = tk.LabelFrame(sidebar, text="Votes (1=yes,0=no)")
+        self.vote_vars = [tk.IntVar(value=1) for _ in range(constants.PLAYER_COUNT)]
+        for i, var in enumerate(self.vote_vars):
+            tk.Checkbutton(self.vote_frame, text=f"P{i}", variable=var).pack(anchor="w")
+        self.vote_frame.pack(pady=4)
 
-    def _update_plot(self) -> None:
-        self.ax.clear()
-        self.ax.bar([
-            "Liberal",
-            "Fascist",
-        ], [self.game.liberal_policies, self.game.fascist_policies], color=["blue", "red"])
-        self.ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
-        self.ax.set_title(f"Round {self.game.round}")
-        self.canvas.draw()
+        self.bias_frame = tk.LabelFrame(sidebar, text="Policy bias")
+        self.pres_var = tk.IntVar(value=1)
+        self.chan_var = tk.IntVar(value=1)
+        tk.Checkbutton(self.bias_frame, text="President liberal", variable=self.pres_var).pack(anchor="w")
+        tk.Checkbutton(self.bias_frame, text="Chancellor liberal", variable=self.chan_var).pack(anchor="w")
+        self.bias_frame.pack(pady=4)
 
-    def next_round(self) -> None:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            winner = self.game.play_round(interactive=False)
-        self._append(buf.getvalue())
-        self._update_plot()
+        self.resolve_btn = tk.Button(sidebar, text="Resolve", command=self.resolve_step, state=tk.DISABLED)
+        self.resolve_btn.pack(pady=4)
+
+        self.fig, self.axes = plt.subplots(2, 2, figsize=(5, 4))
+        self.fig.tight_layout()
+        self.fig_canvas = FigureCanvasTkAgg(self.fig, master=sidebar)
+        self.fig_canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        # --- state -------------------------------------------------------
+        self.player_items: Dict[int, int] = {}
+        self.state = "idle"
+        self.candidate: Optional[int] = None
+        self.chancellor: Optional[int] = None
+        self.target: Optional[int] = None
+        self.vote_probs = None
+
+        self._append_log("Game started.\n")
+        self.draw_players()
+        self.update_plots()
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        self.log.insert(tk.END, text)
+        self.log.see(tk.END)
+
+    def draw_players(self) -> None:
+        self.canvas.delete("all")
+        cx = cy = CANVAS_SIZE // 2
+        for p in self.game.players:
+            angle = 2 * math.pi * p.index / self.game.num_players
+            x = cx + TABLE_RADIUS * math.cos(angle)
+            y = cy + TABLE_RADIUS * math.sin(angle)
+            color = "blue" if p.role == "liberal" else "red"
+            if not p.alive:
+                color = "gray"
+            item = self.canvas.create_oval(
+                x - PLAYER_RADIUS,
+                y - PLAYER_RADIUS,
+                x + PLAYER_RADIUS,
+                y + PLAYER_RADIUS,
+                fill=color,
+                outline="gold" if p.index == self.game.president else "black",
+                width=3 if p.index == self.game.president else 1,
+            )
+            self.canvas.create_text(x, y, text=str(p.index), fill="white")
+            self.player_items[p.index] = item
+
+    def highlight_candidate(self) -> None:
+        for idx, item in self.player_items.items():
+            if idx == self.candidate:
+                self.canvas.itemconfigure(item, outline="green", width=3)
+            else:
+                width = 3 if idx == self.game.president else 1
+                outline = "gold" if idx == self.game.president else "black"
+                self.canvas.itemconfigure(item, outline=outline, width=width)
+
+    def _on_canvas_click(self, event) -> None:
+        idx = self._player_at(event.x, event.y)
+        if idx is None:
+            return
+        if self.state == "select_chancellor":
+            if idx == self.game.president or not self.game.players[idx].alive:
+                return
+            self.candidate = idx
+            self.highlight_candidate()
+            alive = self.game._alive_players()
+            for p in alive:
+                self.vote_vars[p.index].set(1 if p.role == self.game.players[idx].role else 0)
+            self.instr.config(text="Adjust votes then click Resolve")
+            self.resolve_btn.config(state=tk.NORMAL)
+            self.state = "vote_ready"
+        elif self.state == "bullet":
+            if idx == self.game.president or not self.game.players[idx].alive:
+                return
+            self.target = idx
+            self.resolve_step()
+
+    def _player_at(self, x: int, y: int) -> Optional[int]:
+        for idx, item in self.player_items.items():
+            bb = self.canvas.bbox(item)
+            if bb and bb[0] <= x <= bb[2] and bb[1] <= y <= bb[3]:
+                return idx
+        return None
+
+    # ------------------------------------------------------------------
+    def start_round(self) -> None:
+        self._append_log(f"\n--- Round {self.game.round + 1} ---\n")
+        self.draw_players()
+        self.update_plots()
+        self.instr.config(text="Select chancellor by clicking a player")
+        self.state = "select_chancellor"
+        self.candidate = None
+        self.chancellor = None
+        self.target = None
+        self.resolve_btn.config(state=tk.DISABLED)
+
+    def resolve_step(self) -> None:
+        if self.state == "vote_ready":
+            alive = self.game._alive_players()
+            votes = [self.vote_vars[p.index].get() for p in alive]
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                chancellor, self.vote_probs = self.game._elect_chancellor(False, self.candidate, votes)
+            self.chancellor = chancellor
+            self._append_log(buf.getvalue())
+            self.update_plots()
+            if chancellor is None:
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    self.game._enact_policy(None, False)
+                self._append_log(buf.getvalue())
+                self.end_round()
+            else:
+                self.instr.config(text="Set policy biases then click Resolve")
+                self.resolve_btn.config(state=tk.NORMAL)
+                self.pres_var.set(1 if self.game.players[self.game.president].role == "liberal" else 0)
+                self.chan_var.set(1 if self.game.players[chancellor].role == "liberal" else 0)
+                self.state = "policy_ready"
+
+        elif self.state == "policy_ready":
+            pres_bias = self.pres_var.get()
+            chan_bias = self.chan_var.get()
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.game._enact_policy(self.chancellor, False, pres_bias, chan_bias)
+            self._append_log(buf.getvalue())
+            self.update_plots()
+            if self.game.fascist_policies in (4, 5):
+                self.instr.config(text="Click a player to shoot")
+                self.state = "bullet"
+                self.resolve_btn.config(state=tk.DISABLED)
+            else:
+                self.end_round()
+
+        elif self.state == "bullet":
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.game._bullet_phase(False, self.target)
+            self._append_log(buf.getvalue())
+            self.update_plots()
+            self.end_round()
+
+    def end_round(self) -> None:
+        winner = self.game._check_winner(self.chancellor)
         if winner:
-            self._append(f"\n{winner} win the game!\n")
+            self._append_log(f"\n{winner} win the game!\n")
+            self.update_plots()
+            self.instr.config(text="Game over")
             self.next_btn.config(state=tk.DISABLED)
+            self.resolve_btn.config(state=tk.DISABLED)
+            return
+        self.game._next_president()
+        self.draw_players()
+        self.update_plots()
+        if self.game.fascist_policies >= 3:
+            self._append_log("Fascists can win by electing Hitler.\n")
+        self.instr.config(text="Round finished. Click 'Next Round'")
+        self.state = "idle"
+        self.resolve_btn.config(state=tk.DISABLED)
+
+    # ------------------------------------------------------------------
+    def update_plots(self) -> None:
+        ax_hitler, ax_vote, ax_fail, ax_policies = self.axes.flatten()
+        ax_hitler.clear()
+        labels = [str(k) for k in self.game.hitler_dist.keys()]
+        probs = [self.game.hitler_dist[k] for k in self.game.hitler_dist]
+        ax_hitler.bar(labels, probs, color="orange")
+        ax_hitler.set_ylim(0, 1)
+        ax_hitler.set_title("Hitler dist")
+
+        ax_vote.clear()
+        if self.vote_probs is not None:
+            ax_vote.bar(["Fail", "Success"], self.vote_probs, color="purple")
+            ax_vote.set_ylim(0, 1)
+        ax_vote.set_title("Vote prob")
+
+        ax_fail.clear()
+        ax_fail.bar(["Fails"], [self.game.failed_elections], color="gray")
+        ax_fail.set_ylim(0, 3)
+        ax_fail.set_title("Failed elections")
+
+        ax_policies.clear()
+        ax_policies.bar(["Lib", "Fas"], [self.game.liberal_policies, self.game.fascist_policies], color=["blue", "red"])
+        ax_policies.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
+        ax_policies.set_title("Policies")
+
+        self.fig_canvas.draw()
 
 
 def main() -> None:

--- a/quantum_secret_hitler/gui.py
+++ b/quantum_secret_hitler/gui.py
@@ -67,8 +67,10 @@ class SecretHitlerGUI(tk.Tk):
         self.resolve_btn = tk.Button(sidebar, text="Resolve", command=self.resolve_step, state=tk.DISABLED)
         self.resolve_btn.pack(pady=4)
 
+        # probability plots
         self.fig, self.axes = plt.subplots(2, 2, figsize=(5, 4))
-        self.fig.tight_layout()
+        self.fig.subplots_adjust(hspace=0.5, wspace=0.4)
+        self.fig.tight_layout(pad=2.0)
         self.fig_canvas = FigureCanvasTkAgg(self.fig, master=sidebar)
         self.fig_canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
 
@@ -232,24 +234,29 @@ class SecretHitlerGUI(tk.Tk):
         probs = [self.game.hitler_dist[k] for k in self.game.hitler_dist]
         ax_hitler.bar(labels, probs, color="orange")
         ax_hitler.set_ylim(0, 1)
-        ax_hitler.set_title("Hitler dist")
+        ax_hitler.set_title("Hitler dist", fontsize=8)
+        ax_hitler.tick_params(labelsize=8)
 
         ax_vote.clear()
         if self.vote_probs is not None:
             ax_vote.bar(["Fail", "Success"], self.vote_probs, color="purple")
             ax_vote.set_ylim(0, 1)
-        ax_vote.set_title("Vote prob")
+        ax_vote.set_title("Vote prob", fontsize=8)
+        ax_vote.tick_params(labelsize=8)
 
         ax_fail.clear()
         ax_fail.bar(["Fails"], [self.game.failed_elections], color="gray")
         ax_fail.set_ylim(0, 3)
-        ax_fail.set_title("Failed elections")
+        ax_fail.set_title("Failed elections", fontsize=8)
+        ax_fail.tick_params(labelsize=8)
 
         ax_policies.clear()
         ax_policies.bar(["Lib", "Fas"], [self.game.liberal_policies, self.game.fascist_policies], color=["blue", "red"])
         ax_policies.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
-        ax_policies.set_title("Policies")
+        ax_policies.set_title("Policies", fontsize=8)
+        ax_policies.tick_params(labelsize=8)
 
+        self.fig.tight_layout(pad=2.0)
         self.fig_canvas.draw()
 
 

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -1,0 +1,342 @@
+"""Simple simulation of the Quantum Secret Hitler game.
+
+This module provides a ``QuantumSecretHitlerGame`` class capable of running a
+single simulated game with the rules sketched in ``IQU_CODE_FEST_CapitalQ.pdf``.
+The implementation focuses on the quantum-inspired mechanics while keeping the
+control flow lightweight so it can run entirely offline.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import List, Optional, Dict, Tuple
+from argparse import ArgumentParser
+
+import matplotlib.pyplot as plt
+
+from . import constants
+from .game import (
+    uniform_role_state,
+    uniform_hitler_state,
+    quantum_vote,
+    policy_selection,
+    biased_bullet_state,
+)
+
+
+class Player:
+    """Represents a player in the game."""
+
+    def __init__(self, index: int, role: str) -> None:
+        self.index = index
+        self.role = role  # "liberal" or "fascist"
+        self.alive = True
+
+
+class QuantumSecretHitlerGame:
+    """Manage a single run of the game with 10 players."""
+
+    def __init__(self) -> None:
+        self.num_players = constants.PLAYER_COUNT
+        self.players = self._assign_roles()
+        self.hitler, self.hitler_dist = self._assign_hitler()
+        self.president = np.random.randint(self.num_players)
+
+        print("Initial roles:")
+        for p in self.players:
+            print(f"  Player {p.index}: {p.role}")
+        lib_prob = constants.LIBERAL_PLAYERS / constants.PLAYER_COUNT
+        print(
+            f"Role probabilities -> Liberal: {lib_prob:.2f}, Fascist: {1-lib_prob:.2f}"
+        )
+        fascists = [p.index for p in self.players if p.role == "fascist"]
+        if fascists:
+            hit_prob = 1 / len(fascists)
+            print(
+                f"Hitler probability for each fascist: {hit_prob:.2f}"
+            )
+        print(f"Hitler is player {self.hitler}\n")
+
+        self.liberal_policies = 0
+        self.fascist_policies = 0
+        self.failed_elections = 0
+        self.round = 0
+
+        # Matplotlib figure for optional visualization
+        self._fig = None
+        self._ax = None
+        self._prob_fig = None
+        self._prob_ax = None
+
+    # ------------------------------------------------------------------
+    # Role assignment helpers
+    # ------------------------------------------------------------------
+    def _assign_roles(self) -> List[Player]:
+        """Measure ``|Ψ_role⟩`` once to distribute liberal/fascist roles."""
+        state = uniform_role_state(
+            constants.PLAYER_COUNT, constants.LIBERAL_PLAYERS
+        )
+        probs = state.probabilities()
+        from math import comb
+        uniform_prob = 1 / comb(constants.PLAYER_COUNT, constants.LIBERAL_PLAYERS)
+        print(f"Role assignment probability for each valid state: {uniform_prob:.4f}")
+        outcome = np.random.choice(2 ** self.num_players, p=probs)
+        bits = list(map(int, bin(outcome)[2:].zfill(self.num_players)))
+        players: List[Player] = []
+        for i, b in enumerate(bits):
+            role = "liberal" if b == 0 else "fascist"
+            players.append(Player(i, role))
+        return players
+
+    def _assign_hitler(self) -> Tuple[int, dict[int, float]]:
+        """Randomly pick the initial Hitler and return the starting distribution."""
+        fascists = [p.index for p in self.players if p.role == "fascist"]
+        _ = uniform_hitler_state(len(fascists))  # state only for parity with PDF
+        hit_prob = 1 / len(fascists)
+        dist = {f: hit_prob for f in fascists}
+        print(f"Initial Hitler distribution: {dist}")
+        outcome = np.random.choice(fascists, p=[hit_prob] * len(fascists))
+        return outcome, dist
+
+    # ------------------------------------------------------------------
+    # Basic helpers
+    # ------------------------------------------------------------------
+    def _alive_players(self) -> List[Player]:
+        return [p for p in self.players if p.alive]
+
+    def _bias_hitler_distribution(self, player: int) -> None:
+        """Increase the probability that ``player`` is Hitler."""
+        if player not in self.hitler_dist:
+            return
+        self.hitler_dist[player] *= constants.HITLER_BIAS_FACTOR
+        total = sum(self.hitler_dist.values())
+        for k in self.hitler_dist:
+            self.hitler_dist[k] /= total
+
+    def _print_hitler_distribution(self) -> None:
+        dist = {k: round(v, 2) for k, v in self.hitler_dist.items()}
+        print(f"Current Hitler distribution: {dist}")
+
+    def _visualize(self) -> None:
+        """Show a bar chart of the policy counts."""
+        if self._fig is None:
+            plt.ion()
+            self._fig, self._ax = plt.subplots()
+            self._ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
+        self._ax.clear()
+        self._ax.bar(['Liberal', 'Fascist'], [self.liberal_policies, self.fascist_policies], color=['blue', 'red'])
+        self._ax.set_title(f"Round {self.round}")
+        self._fig.canvas.draw()
+        self._fig.canvas.flush_events()
+
+    def _plot_distribution(self, labels: List[str], probs: List[float], title: str) -> None:
+        """Display a probability distribution as a bar chart."""
+        if self._prob_fig is None:
+            plt.ion()
+            self._prob_fig, self._prob_ax = plt.subplots()
+        self._prob_ax.clear()
+        self._prob_ax.bar(labels, probs, color='green')
+        self._prob_ax.set_ylim(0, 1)
+        self._prob_ax.set_title(title)
+        self._prob_fig.canvas.draw()
+        self._prob_fig.canvas.flush_events()
+
+    def _next_president(self) -> None:
+        idx = self.president
+        while True:
+            idx = (idx + 1) % self.num_players
+            if self.players[idx].alive:
+                self.president = idx
+                break
+
+    # ------------------------------------------------------------------
+    # Game mechanics
+    # ------------------------------------------------------------------
+    def _elect_chancellor(self, interactive: bool = False) -> Optional[int]:
+        alive = self._alive_players()
+        choices = [p.index for p in alive if p.index != self.president]
+        if interactive:
+            try:
+                raw = input(f"Choose chancellor from {choices} (enter for random): ")
+                candidate = int(raw) if raw.strip() else int(np.random.choice(choices))
+            except ValueError:
+                candidate = int(np.random.choice(choices))
+        else:
+            candidate = int(np.random.choice(choices))
+
+        print(f"President {self.president} nominates player {candidate} as chancellor")
+
+        if interactive:
+            raw = input(f"Enter {len(alive)} votes as 0/1 separated by spaces (enter for auto): ")
+            if raw.strip():
+                bits = [int(b) for b in raw.split() if b in '01']
+                if len(bits) == len(alive):
+                    votes = bits
+                else:
+                    votes = [1 if p.role == self.players[candidate].role else 0 for p in alive]
+            else:
+                votes = [1 if p.role == self.players[candidate].role else 0 for p in alive]
+        else:
+            votes = [1 if p.role == self.players[candidate].role else 0 for p in alive]
+
+        print(f"Votes: {votes}")
+        success, state = quantum_vote(votes, constants.VOTE_PHI)
+        probs = state.probabilities()
+        print(
+            f"Vote probabilities -> Fail: {probs[0]:.2f}, Success: {probs[1]:.2f}"
+        )
+        if interactive:
+            self._plot_distribution(["Fail", "Success"], list(probs), "Vote outcome")
+        if success:
+            print("Election successful")
+        else:
+            print("Election failed")
+        if success:
+            self.failed_elections = 0
+            return candidate
+        self.failed_elections += 1
+        return None
+
+    def _enact_policy(self, chancellor: Optional[int], interactive: bool = False) -> None:
+        if chancellor is None:
+            if self.failed_elections >= 3:
+                policy, state = policy_selection(0, 0, constants.POLICY_PHI)
+                probs = state.probabilities()
+                print(
+                    f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
+                )
+                if interactive:
+                    self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+                self.failed_elections = 0
+                print("Top-deck policy due to anarchy")
+            else:
+                print("No chancellor elected")
+                return
+        else:
+            if interactive:
+                ans = input(
+                    f"Should president {self.president} favour liberal policy? (y/n, enter for role-based) "
+                ).strip().lower()
+                if ans in {"y", "n"}:
+                    pres_bias = 1 if ans == "y" else 0
+                else:
+                    pres_bias = 1 if self.players[self.president].role == "liberal" else 0
+                ans = input(
+                    f"Should chancellor {chancellor} favour liberal policy? (y/n, enter for role-based) "
+                ).strip().lower()
+                if ans in {"y", "n"}:
+                    chan_bias = 1 if ans == "y" else 0
+                else:
+                    chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
+            else:
+                pres_bias = 1 if self.players[self.president].role == "liberal" else 0
+                chan_bias = 1 if self.players[chancellor].role == "liberal" else 0
+            policy, state = policy_selection(pres_bias, chan_bias, constants.POLICY_PHI)
+            if pres_bias == 0:
+                self._bias_hitler_distribution(self.president)
+            if chan_bias == 0:
+                self._bias_hitler_distribution(chancellor)
+            probs = state.probabilities()
+            print(
+                f"Policy probabilities -> Liberal: {probs[0]:.2f}, Fascist: {probs[1]:.2f}"
+            )
+            if interactive:
+                self._plot_distribution(["Liberal", "Fascist"], list(probs), "Policy draw")
+            print(
+                f"Chancellor {chancellor} enacts {'Liberal' if policy == 0 else 'Fascist'} policy"
+            )
+
+        if policy == 0:
+            self.liberal_policies += 1
+        else:
+            self.fascist_policies += 1
+        print(
+            f"Policies -> Liberal: {self.liberal_policies}, Fascist: {self.fascist_policies}"
+        )
+        self._print_hitler_distribution()
+
+    def _bullet_phase(self, interactive: bool = False) -> None:
+        if self.fascist_policies not in (4, 5):
+            return
+        alive = self._alive_players()
+        choices = [p.index for p in alive if p.index != self.president]
+        if interactive:
+            try:
+                raw = input(f"Choose bullet target from {choices} (enter for random): ")
+                target = int(raw) if raw.strip() else int(np.random.choice(choices))
+            except ValueError:
+                target = int(np.random.choice(choices))
+        else:
+            target = int(np.random.choice(choices))
+        print(f"President {self.president} chooses policy kill targeting player {target}")
+        target_local = [p.index for p in alive].index(target)
+        bullet_state = biased_bullet_state(len(alive), target_local)
+        probs = bullet_state.probabilities()
+        dist = {alive[i].index: round(prob, 2) for i, prob in enumerate(probs)}
+        print(f"Bullet probabilities: {dist}")
+        if interactive:
+            self._plot_distribution([str(p.index) for p in alive], list(probs), "Bullet outcome")
+        shot_idx_local = int(np.random.choice(len(alive), p=probs))
+        shot = alive[shot_idx_local].index
+        self.players[shot].alive = False
+        print(f"Player {shot} was shot")
+        if shot == self.hitler:
+            print("Hitler was eliminated!")
+        if shot == self.hitler:
+            # Immediate liberal victory
+            self.liberal_policies = constants.LIBERAL_WIN_POLICIES
+        self._print_hitler_distribution()
+
+    def _check_winner(self, chancellor: Optional[int]) -> Optional[str]:
+        if (
+            chancellor is not None
+            and chancellor == self.hitler
+            and self.fascist_policies >= 3
+        ):
+            print("Hitler elected as chancellor - Fascists win!")
+            return "Fascists"
+        if self.fascist_policies >= constants.FASCIST_WIN_POLICIES:
+            print("Fascists have enough policies to win")
+            return "Fascists"
+        if self.liberal_policies >= constants.LIBERAL_WIN_POLICIES:
+            print("Liberals enacted enough policies to win")
+            return "Liberals"
+        return None
+
+    def play_round(self, interactive: bool = False) -> Optional[str]:
+        self.round += 1
+        print(f"\n--- Round {self.round} ---")
+        self._print_hitler_distribution()
+        print(f"President is {self.president}")
+        chancellor = self._elect_chancellor(interactive)
+        self._enact_policy(chancellor, interactive)
+        self._bullet_phase(interactive)
+        winner = self._check_winner(chancellor)
+        self._next_president()
+        return winner
+
+    def play_game(self, interactive: bool = False) -> str:
+        if interactive:
+            print("Interactive mode. Close the plot window to exit.")
+        while True:
+            result = self.play_round(interactive)
+            if interactive:
+                self._visualize()
+                ans = input("Press Enter for next round or 'q' to quit: ")
+                if ans.lower().startswith("q"):
+                    print("Game aborted.")
+                    break
+            if result:
+                if interactive:
+                    self._visualize()
+                print(f"\n{result} win the game!")
+                return result
+        return "Aborted"
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Quantum Secret Hitler simulation")
+    parser.add_argument("--auto", action="store_true", help="Run without prompts")
+    args = parser.parse_args()
+    game = QuantumSecretHitlerGame()
+    game.play_game(interactive=not args.auto)

--- a/quantum_secret_hitler/simulate.py
+++ b/quantum_secret_hitler/simulate.py
@@ -123,9 +123,12 @@ class QuantumSecretHitlerGame:
             plt.ion()
             self._fig, self._ax = plt.subplots()
             self._ax.set_ylim(0, max(constants.LIBERAL_WIN_POLICIES, constants.FASCIST_WIN_POLICIES))
+            self._fig.tight_layout(pad=2.0)
         self._ax.clear()
         self._ax.bar(['Liberal', 'Fascist'], [self.liberal_policies, self.fascist_policies], color=['blue', 'red'])
-        self._ax.set_title(f"Round {self.round}")
+        self._ax.set_title(f"Round {self.round}", fontsize=8)
+        self._ax.tick_params(labelsize=8)
+        self._fig.tight_layout(pad=2.0)
         self._fig.canvas.draw()
         self._fig.canvas.flush_events()
 
@@ -134,10 +137,13 @@ class QuantumSecretHitlerGame:
         if self._prob_fig is None:
             plt.ion()
             self._prob_fig, self._prob_ax = plt.subplots()
+            self._prob_fig.tight_layout(pad=2.0)
         self._prob_ax.clear()
         self._prob_ax.bar(labels, probs, color='green')
         self._prob_ax.set_ylim(0, 1)
-        self._prob_ax.set_title(title)
+        self._prob_ax.set_title(title, fontsize=8)
+        self._prob_ax.tick_params(labelsize=8)
+        self._prob_fig.tight_layout(pad=2.0)
         self._prob_fig.canvas.draw()
         self._prob_fig.canvas.flush_events()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pylatexenc==2.10
 plotly==6.0.1
 imageio==2.37.0
 tqdm==4.67.1
+


### PR DESCRIPTION
## Summary
- allow choosing the enacted policy during interactive play
- compute `POLICY_PHI` from the target liberal probability
- fix uniform role distribution probability calculation
- players now only bias policy draws rather than force an outcome
- add a basic Tkinter GUI frontend

## Testing
- `python -m compileall quantum_secret_hitler`
- `python -m quantum_secret_hitler.simulate --auto`
- `python -m quantum_secret_hitler.gui` *(fails: no display available)*

------
https://chatgpt.com/codex/tasks/task_e_68557c8900988322a716137afbd7b95d